### PR TITLE
Remove unused import causing server startup error

### DIFF
--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -11,7 +11,6 @@ dotenv.config();
 
 import express from 'express';
 import * as fs from 'fs';
-import { createProxyMiddleware } from 'http-proxy-middleware';
 import * as path from 'path';
 
 import { HtmlWritable } from './utils/HtmlWritable';


### PR DESCRIPTION
Удалил не используемый импорт, из-за которого по команде `yarn docker:dev` в консоли вываливалась ошибка и сервер не стартовал на 5000 порту.