### PR TITLE
Add no-unused vars rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'simple-import-sort', 'react-hooks'],
   rules: {
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error'],
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     '@typescript-eslint/ban-ts-comment': 1,
     '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],


### PR DESCRIPTION
Добавил в eslint правило, в соответствии с которым не используемые переменные (в том числе импорты) теперь будут помечаться как error, а не как warning. 
Более строгие правила линтинга помогут избежать ошибок в приложении.